### PR TITLE
37 make shoot direction dependant of fighter

### DIFF
--- a/code/fighter.gd
+++ b/code/fighter.gd
@@ -4,9 +4,8 @@ extends KinematicBody2D
 # NOTE(hugo) : Input map
 const INPUT_UP = 0
 const INPUT_DOWN = 1
-const INPUT_LEFT = 2
-const INPUT_RIGHT = 3
-var InputMap = ["", "", "", ""]
+const INPUT_SHOOT = 2
+var InputMap = ["", "", ""]
 
 export var AccelerationNorm = 6000
 export var Drag = 10
@@ -23,16 +22,16 @@ var ProjectionAcceleration = Vector2(0.0, 0.0)
 var LastHitSide
 var IsControllable = true
 
-export(Vector2) var BulletVelocity = Vector2(90.0, 0.0)
+var BulletDir = Vector2(1.0, 0.0)
+export(float, 0.0, 150.0) var BulletSpeed = 90.0
 
-func set_input_map(UpInput, DownInput, LeftInput, RightInput):
+func set_input_map(UpInput, DownInput, ShootInput):
 	InputMap[INPUT_UP] = UpInput
 	InputMap[INPUT_DOWN] = DownInput
-	InputMap[INPUT_LEFT] = LeftInput
-	InputMap[INPUT_RIGHT] = RightInput
+	InputMap[INPUT_SHOOT] = ShootInput
 
 func set_default_input_map():
-	set_input_map("up0", "down0", "left0", "right0")
+	set_input_map("up0", "down0", "right0")
 
 func _ready():
 	set_fixed_process(true)
@@ -60,7 +59,7 @@ func _fixed_process(dt):
 			Acceleration += AccelerationNorm * Vector2(0, -1)
 		if(Input.is_action_pressed(InputMap[INPUT_DOWN])):
 			Acceleration += AccelerationNorm * Vector2(0, 1)
-		if(Input.is_action_pressed(InputMap[INPUT_RIGHT])):
+		if(Input.is_action_pressed(InputMap[INPUT_SHOOT])):
 			shoot()
 
 		Velocity += dt * Acceleration - dt * Drag * Velocity
@@ -84,7 +83,7 @@ func shoot():
 	var Root = get_tree().get_root().get_node("Game")
 	var BulletNode = preload("res://Bullet.tscn").instance()
 	BulletNode.set_pos(get_pos())
-	BulletNode.set_velocity(BulletVelocity)
+	BulletNode.set_velocity(BulletSpeed * BulletDir)
 	Root.add_child(BulletNode)
 
 func set_hit_side_to_left(EnteredHitbox):

--- a/code/fighter.gd
+++ b/code/fighter.gd
@@ -1,6 +1,13 @@
 
 extends KinematicBody2D
 
+# NOTE(hugo) : Input map
+const INPUT_UP = 0
+const INPUT_DOWN = 1
+const INPUT_LEFT = 2
+const INPUT_RIGHT = 3
+var InputMap = ["", "", "", ""]
+
 export var AccelerationNorm = 6000
 export var Drag = 10
 export var HitlagTeleportDelta = 100
@@ -18,6 +25,15 @@ var IsControllable = true
 
 export(Vector2) var BulletVelocity = Vector2(90.0, 0.0)
 
+func set_input_map(UpInput, DownInput, LeftInput, RightInput):
+	InputMap[INPUT_UP] = UpInput
+	InputMap[INPUT_DOWN] = DownInput
+	InputMap[INPUT_LEFT] = LeftInput
+	InputMap[INPUT_RIGHT] = RightInput
+
+func set_default_input_map():
+	set_input_map("up0", "down0", "left0", "right0")
+
 func _ready():
 	set_fixed_process(true)
 	set_pos(InitPos)
@@ -34,15 +50,17 @@ func _ready():
 	LeftAreaNode.connect("area_enter", self, "set_hit_side_to_left")
 	RightAreaNode.connect("area_enter", self, "set_hit_side_to_right")
 
+	set_default_input_map()
+
 
 func _fixed_process(dt):
 
 	if(IsControllable && (!Frozen)):
-		if(Input.is_action_pressed("up")):
+		if(Input.is_action_pressed(InputMap[INPUT_UP])):
 			Acceleration += AccelerationNorm * Vector2(0, -1)
-		if(Input.is_action_pressed("down")):
+		if(Input.is_action_pressed(InputMap[INPUT_DOWN])):
 			Acceleration += AccelerationNorm * Vector2(0, 1)
-		if(Input.is_action_pressed("right")):
+		if(Input.is_action_pressed(InputMap[INPUT_RIGHT])):
 			shoot()
 
 		Velocity += dt * Acceleration - dt * Drag * Velocity

--- a/code/fighter.gd
+++ b/code/fighter.gd
@@ -14,6 +14,7 @@ var FreezeInput = Vector2(0.0, 0.0)
 var FreezeTimerNode
 var ProjectionAcceleration = Vector2(0.0, 0.0)
 var LastHitSide
+var IsControllable = true
 
 export(Vector2) var BulletVelocity = Vector2(90.0, 0.0)
 
@@ -36,7 +37,7 @@ func _ready():
 
 func _fixed_process(dt):
 
-	if(!Frozen):
+	if(IsControllable && (!Frozen)):
 		if(Input.is_action_pressed("up")):
 			Acceleration += AccelerationNorm * Vector2(0, -1)
 		if(Input.is_action_pressed("down")):

--- a/code/game.gd
+++ b/code/game.gd
@@ -31,7 +31,7 @@ func _ready():
 	# NOTE(hugo) : Settings of the second fighter
 	var Fighter2 = find_node("Fighter2")
 	Fighter2.set_pos(Vector2(600, 400))
-	Fighter2.IsControllable = false
+	Fighter2.set_input_map("up1", "down1", "left1", "right1")
 
 
 func respawn_hitbox():

--- a/code/game.gd
+++ b/code/game.gd
@@ -24,8 +24,15 @@ func _ready():
 	var TimerNode = find_node("Timer")
 	TimerNode.connect("timeout", self, "respawn_hitbox")
 
+	# NOTE(hugo) : Settings of the first fighter
 	var Fighter = find_node("Fighter")
 	Fighter.set_pos(Vector2(300, 400))
+
+	# NOTE(hugo) : Settings of the second fighter
+	var Fighter2 = find_node("Fighter2")
+	Fighter2.set_pos(Vector2(600, 400))
+	Fighter2.IsControllable = false
+
 
 func respawn_hitbox():
 	var HitboxExists = HitboxWeakRef.get_ref()

--- a/code/game.gd
+++ b/code/game.gd
@@ -31,7 +31,8 @@ func _ready():
 	# NOTE(hugo) : Settings of the second fighter
 	var Fighter2 = find_node("Fighter2")
 	Fighter2.set_pos(Vector2(600, 400))
-	Fighter2.set_input_map("up1", "down1", "left1", "right1")
+	Fighter2.set_input_map("up1", "down1", "left1")
+	Fighter2.BulletDir = Vector2(-1.0, 0.0)
 
 
 func respawn_hitbox():

--- a/engine.cfg
+++ b/engine.cfg
@@ -6,7 +6,11 @@ icon="res://icon.png"
 
 [input]
 
-right=[key(Right)]
-left=[key(Left)]
-up=[key(Up)]
-down=[key(Down)]
+right1=[key(D)]
+left1=[key(Q)]
+up1=[key(Z)]
+down1=[key(S)]
+right0=[key(Right)]
+left0=[key(Left)]
+up0=[key(Up)]
+down0=[key(Down)]

--- a/game_scene.tscn
+++ b/game_scene.tscn
@@ -16,6 +16,10 @@ script/script = ExtResource( 1 )
 
 transform/pos = Vector2( 446.203, 356.418 )
 
+[node name="Fighter2" parent="." instance=ExtResource( 2 )]
+
+transform/pos = Vector2( 708.755, 357.778 )
+
 [node name="Wall0" type="StaticBody2D" parent="."]
 
 transform/pos = Vector2( -7.51233, -45.074 )


### PR DESCRIPTION
Input map has changed a little bit. I prefer using only inputs that will be used in-game (UP/DOWN/SHOOT for now) rather than the basic one (UP/DOWN/LEFT/RIGHT) because SHOOT input can be either LEFT or RIGHT depending on the fighter